### PR TITLE
Fix RTL alignment of contact button text

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -952,7 +952,7 @@ section {
 [dir="rtl"] .btn-text {
     order: 1; /* Text appears first */
     text-align: right;
-    align-items: flex-end;
+    align-items: flex-start;
     direction: rtl; /* Only text direction is RTL */
     width: 100%;
 }


### PR DESCRIPTION
## Summary
- align contact button text to the right when Hebrew is selected

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adbd7fe02c833280271a015a97c3fd