### PR TITLE
Keep phone number LTR in RTL layouts

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -89,7 +89,7 @@
                     <span class="btn-icon" role="img" aria-hidden="true">💬</span>
                     <span class="btn-text">
                         <span class="btn-title" data-i18n="contact.sms">Send SMS</span>
-                        <span class="btn-subtitle">+972&#8209;50&#8209;971&#8209;3042</span>
+                        <span class="btn-subtitle phone-number" dir="ltr">+972&#8209;50&#8209;971&#8209;3042</span>
                     </span>
                 </a>
                 
@@ -111,7 +111,7 @@
                     <span class="btn-icon" role="img" aria-hidden="true">📞</span>
                     <span class="btn-text">
                         <span class="btn-title" data-i18n="contact.call">Call</span>
-                        <span class="btn-subtitle">+972&#8209;50&#8209;971&#8209;3042</span>
+                        <span class="btn-subtitle phone-number" dir="ltr">+972&#8209;50&#8209;971&#8209;3042</span>
                     </span>
                 </a>
             </div>

--- a/docs/style.css
+++ b/docs/style.css
@@ -545,6 +545,11 @@ section {
     max-width: 100%;
 }
 
+.phone-number {
+    direction: ltr;
+    unicode-bidi: bidi-override;
+}
+
 /* Desktop button improvements */
 @media (min-width: 768px) {
     .btn-icon {


### PR DESCRIPTION
## Summary
- ensure phone number always renders left-to-right by adding `phone-number` class with LTR direction
- apply `dir="ltr"` on phone number spans so they stay LTR while aligning with locale

## Testing
- `python -m py_compile scripts/generate_tag.py`


------
https://chatgpt.com/codex/tasks/task_e_68adc1ff94b083328968879b9a76814e